### PR TITLE
Add metadata to get install working

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     author='Bram van Wersch and Diego Montiel Gonzalez',
     author_email='b.vanwersch@erasmusmc.nl',
     description='Tool for human Y-chromosomal phylogenetic analysis and haplogroup inference.',
+    long_description='Tool for human Y-chromosomal phylogenetic analysis and haplogroup inference.',
+    long_description_content_type='text/plain',
+    platforms=[],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
I ran into a problem setting up Yleaf, which I found to be fixed by adding the metadata elements in this PR. I put pretty minimal metadata into the setup.py, so definitely feel free to add/edit, but the presence of those metadata elements allowed my install to complete successfully.

For reference, here are the errors that I encountered:

<details>
    <summary>First error</summary>

```
Obtaining file:///shared/courseSharedFolders/153784outer/153784/Yleaf
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [34 lines of output]
      /shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/dist.py:700: SetuptoolsDeprecationWarning: As setuptools moves its configuration towards `pyproject.toml`,
      `setuptools.config.parse_configuration` became deprecated.

      For the time being, you can use the `setuptools.config.setupcfg` module
      to access a backward compatible API, but this module is provisional
      and might be removed in the future.

        ignore_option_errors=ignore_option_errors)
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/shared/courseSharedFolders/153784outer/153784/Yleaf/setup.py", line 48, in <module>
          package_data={"yleaf": ["data/*", "config.txt"]}
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
          return distutils.core.setup(**attrs)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 289, in run
          writer(self, ep.name, os.path.join(self.egg_info, ep.name))
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 621, in write_pkg_info
          metadata.write_pkg_info(cmd.egg_info)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 1137, in write_pkg_info
          self.write_pkg_file(pkg_info)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/dist.py", line 166, in write_pkg_file
          long_desc = rfc822_escape(self.get_long_description())
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/util.py", line 511, in rfc822_escape
          lines = header.split('\n')
      AttributeError: 'NoneType' object has no attribute 'split'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

</details>

<details>
    <summary>Second Error</summary>

```
Obtaining file:///shared/courseSharedFolders/153784outer/153784/Yleaf
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [32 lines of output]
      /shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/dist.py:700: SetuptoolsDeprecationWarning: As setuptools moves its configuration towards `pyproject.toml`,
      `setuptools.config.parse_configuration` became deprecated.

      For the time being, you can use the `setuptools.config.setupcfg` module
      to access a backward compatible API, but this module is provisional
      and might be removed in the future.

        ignore_option_errors=ignore_option_errors)
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/shared/courseSharedFolders/153784outer/153784/Yleaf/setup.py", line 49, in <module>
          package_data={"yleaf": ["data/*", "config.txt"]}
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
          return distutils.core.setup(**attrs)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 289, in run
          writer(self, ep.name, os.path.join(self.egg_info, ep.name))
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/command/egg_info.py", line 621, in write_pkg_info
          metadata.write_pkg_info(cmd.egg_info)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 1137, in write_pkg_info
          self.write_pkg_file(pkg_info)
        File "/shared/spack/opt/spack/linux-skylake_avx512/mamba-2.3.0-v2cewishtbh2epr7qwrfpfgxtpimbff6/envs/yleaf/lib/python3.7/site-packages/setuptools/dist.py", line 174, in write_pkg_file
          for platform in self.get_platforms():
      TypeError: 'NoneType' object is not iterable
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

</details>