### PR TITLE
Fix Hg=NA on macOS/Windows: init backbone globals in Pool workers

### DIFF
--- a/yleaf/predict_haplogroup.py
+++ b/yleaf/predict_haplogroup.py
@@ -112,7 +112,11 @@ def main(namespace: argparse.Namespace = None):
     read_backbone_groups()
     final_table = []
 
-    with multiprocessing.Pool(processes=threads) as p:
+    # Pool workers on macOS/Windows use the 'spawn' start method (Python 3.8+
+    # default), which re-imports this module fresh — leaving BACKBONE_GROUPS
+    # and MAIN_HAPLO_GROUPS empty in each worker. Pass read_backbone_groups
+    # as an initializer so every worker hydrates its own copy.
+    with multiprocessing.Pool(processes=threads, initializer=read_backbone_groups) as p:
         predictions = p.map(partial(main_predict_haplogroup, namespace), read_input_folder(in_folder))
 
     for haplotype_dict, best_haplotype_score, folder in predictions:


### PR DESCRIPTION
Closes #41.

## Summary

On macOS and Windows, `python -m yleaf.predict_haplogroup` returns `Hg=NA`
with all QC fields `NA` for every sample, regardless of input. The same
`.out` file produces the expected haplogroup prediction on Linux. Reproduces
with `-t 1` too — not a worker-count interaction.

## Root cause

`main()` populates the module-level globals `BACKBONE_GROUPS` and
`MAIN_HAPLO_GROUPS` via `read_backbone_groups()` in the **parent** process
(predict_haplogroup.py L112), then dispatches `main_predict_haplogroup` through
`multiprocessing.Pool`. Since Python 3.8 the default `mp` start method on
macOS (and Windows) is **spawn**, not **fork** — spawned workers re-import
the module fresh, so both sets start empty in the worker.

Inside the worker, `get_qc1_score()`:
1. Builds `intermediate_states` from the empty `BACKBONE_GROUPS` → `{}`.
2. Iterates the empty `MAIN_HAPLO_GROUPS` looking for `most_specific_backbone` → `None`.
3. Returns `0`.

Every candidate's `qc1_score < threshold`, so the loop in
`get_most_likely_haplotype` (L260) `continue`s through all haplogroups without
ever updating `best_score`, and the function returns the initial `("NA",) * 7`
sentinel (L227). `Pool(processes=1)` still creates a worker subprocess, which
is why `-t 1` reproduces.

Linux is unaffected because `mp` defaults to `fork` there and the populated
globals are inherited.

## Fix

Pass `read_backbone_groups` as the `Pool` initializer so each worker
hydrates its own copy of the globals once at startup. Idempotent, cheap,
no behaviour change on Linux/fork.

## Verification

On macOS (Apple Silicon, Python 3.13), same input `.out` file with
~92,074 informative markers:

| run | before | after |
|---|---|---|
| `-t 1` | `Hg=NA`, QC `NA/NA/NA/NA` | `I-Y9434*(xI-FGC17588,I-Y66964,I-Y128435,I-Y85648)`, QC `1.0/1.0/1.0/1.0` |
| `-t 4` | `Hg=NA`, QC `NA/NA/NA/NA` | `I-Y9434*(xI-FGC17588,I-Y66964,I-Y128435,I-Y85648)`, QC `1.0/1.0/1.0/1.0` |

The Mac result now matches the Linux baseline.

## Test plan

- [x] Reproduce `Hg=NA` on macOS with current `master`
- [x] Apply fix; verify correct haplogroup prediction returned on macOS with `-t 1`
- [x] Verify `-t 4` (multi-worker) also returns correct prediction
- [x] Confirm no behaviour change on Linux (fork inheritance still works; initializer is idempotent)