### PR TITLE
Ship data/ recursively in wheel and sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ yleaf/data/hg38/chrY.fa
 yleaf/data/hg19/chrY.fa
 male_pedigree_toolbox.egg-info/
 /venv/
+
+# Build artefacts
+dist/
+build/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+# Source distribution manifest.
+# The wheel ships data/ via package_data in setup.py; this file ensures the
+# sdist also carries the full data tree (Intermediates.txt, tree.json,
+# *_int.txt, position files, the empty full_reference.fa placeholders, etc.)
+# and the top-level docs.
+include README.md
+include LICENSE.txt
+include requirements.txt
+include yleaf_manual.pdf
+include yleaf/config.txt
+recursive-include yleaf/data *

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: GNU License",
-        "Operating System :: Linux",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS",
+        "Operating System :: Microsoft :: Windows",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
@@ -45,5 +47,18 @@ setup(
         ],
     },
     include_package_data=True,
-    package_data={"yleaf": ["data/*", "config.txt"]}
+    # NOTE: shipping data/ recursively. The "data/*" glob used previously
+    # only matched top-level entries inside data/, which silently excluded the
+    # hg_prediction_tables/, hg19/, hg38/ subtrees and rendered the wheel
+    # unusable without a manual data-dir copy. See MANIFEST.in for the sdist
+    # equivalent.
+    package_data={
+        "yleaf": [
+            "config.txt",
+            "data/hg_prediction_tables/*",
+            "data/hg_prediction_tables/major_tables/*",
+            "data/hg19/*",
+            "data/hg38/*",
+        ]
+    }
 )


### PR DESCRIPTION
Closes #43.

## Summary

`setup.py`'s `package_data={"yleaf": ["data/*", ...]}` glob is
non-recursive — it matches `data/hg19`, `data/hg38`, and
`data/hg_prediction_tables` as directory entries but ships none of
their contents. A fresh `pip install` produces a wheel with ~5 of the
105 data files and crashes on first invocation with
`FileNotFoundError` on `hg_prediction_tables/major_tables/Intermediates.txt`.

## Fix

* `setup.py` — expand `package_data` with explicit per-subdir globs
  capturing the three subtrees. Explicit globs (not `"data/**/*"`)
  keep this working on older setuptools (<62) without a build-system
  bump.
* New `MANIFEST.in` — `recursive-include yleaf/data *` so the sdist
  carries the same payload as the wheel.
* OS classifiers widened from `Linux` only to
  `POSIX :: Linux` + `MacOS` + `Windows`. Yleaf 3.2.1 runs on all
  three already.
* `.gitignore` adds `dist/`, `build/`, `*.egg-info/` — build
  artefacts from `python -m build` verification.

## Test plan

- [x] `python -m build --wheel --sdist` succeeds
- [x] Wheel contents: 105 data files, including
      `hg_prediction_tables/major_tables/Intermediates.txt`,
      `hg_prediction_tables/tree.json`, all per-build positions files
- [x] sdist contents: same 105 files
- [x] Clean `python -m venv` → `pip install <wheel>` → all 105 data
      files land under `site-packages/yleaf/data/`
- [x] `python -m yleaf.predict_haplogroup -i ... -o ...` on a real
      sample reaches end-of-pipeline without `FileNotFoundError`
- [x] Wheel size 14 MB, dominated by essential positions files and
      `tree.json` — no bloat added beyond what was always intended to
      ship