### PR TITLE
Add --report-json sidecar for schema-versioned prediction output

### DIFF
--- a/yleaf/Yleaf.py
+++ b/yleaf/Yleaf.py
@@ -384,7 +384,8 @@ def main():
         LOG.error("Please specify either a bam, a cram, a fastq, or a vcf file")
         raise ValueError("Please specify either a bam, a cram, a fastq, or a vcf file")
     hg_out = out_folder / PREDICTION_OUT_FILE_NAME
-    predict_haplogroup(out_folder, hg_out, args.use_old, args.prediction_quality, args.threads)
+    predict_haplogroup(out_folder, hg_out, args.use_old, args.prediction_quality, args.threads,
+                       report_json=args.report_json)
     if args.draw_haplogroups:
         draw_haplogroups(hg_out, args.collapsed_draw_mode)
 
@@ -478,6 +479,11 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument("-maf", "--minor_allele_frequency", help="Maximum rate of minor allele for it to be considered"
                                                                  " as a private mutation. (default=0.01)",
                         default=0.01, type=float, metavar="FLOAT")
+
+    parser.add_argument("--report-json", dest="report_json", required=False, metavar="PATH", default=None,
+                        help="Optional path. If set, also emit a schema-versioned JSON sidecar of the "
+                             "haplogroup prediction. Replaces the need to parse the 9-column TSV by "
+                             "column position. See predict_haplogroup --report-json.")
 
     args = parser.parse_args()
     return args
@@ -1188,6 +1194,7 @@ def predict_haplogroup(
         use_old: bool,
         prediction_quality: float,
         threads: int,
+        report_json: Union[Path, None] = None,
 ):
     if use_old:
         script = yleaf_constants.SRC_FOLDER / "old_predict_haplogroup.py"
@@ -1196,7 +1203,8 @@ def predict_haplogroup(
     else:
         from yleaf import predict_haplogroup
         namespace = argparse.Namespace(input=path_file, outfile=output,
-                                       minimum_score=prediction_quality, threads=threads)
+                                       minimum_score=prediction_quality, threads=threads,
+                                       report_json=report_json)
         predict_haplogroup.main(namespace)
 
 

--- a/yleaf/predict_haplogroup.py
+++ b/yleaf/predict_haplogroup.py
@@ -12,14 +12,21 @@ Autor: Bram van Wersch
 """
 
 import argparse
+import json
 import multiprocessing
 from functools import partial
 from pathlib import Path
-from typing import Set, Dict, Iterator, List, Any, Union, Tuple
+from typing import Set, Dict, Iterator, List, Any, Union, Tuple, Optional
 import logging
 
+from yleaf import __version__ as _YLEAF_VERSION
 from yleaf import yleaf_constants
 from yleaf.tree import Tree, Node
+
+# Bump this whenever the JSON report shape changes in a way consumers care
+# about (renaming or removing keys, changing semantics of an existing key).
+# Additive changes (new optional keys) do not require a bump.
+JSON_REPORT_SCHEMA_VERSION: int = 1
 
 BACKBONE_GROUPS: Set = set()
 MAIN_HAPLO_GROUPS: Set = set()
@@ -109,8 +116,10 @@ def main(namespace: argparse.Namespace = None):
     in_folder = namespace.input
     output = namespace.outfile
     threads = namespace.threads
+    report_json = getattr(namespace, "report_json", None)
     read_backbone_groups()
     final_table = []
+    final_records: List[Dict[str, Any]] = []
 
     with multiprocessing.Pool(processes=threads) as p:
         predictions = p.map(partial(main_predict_haplogroup, namespace), read_input_folder(in_folder))
@@ -119,8 +128,12 @@ def main(namespace: argparse.Namespace = None):
         if haplotype_dict is None:
             continue
         add_to_final_table(final_table, haplotype_dict, best_haplotype_score, folder)
+        if report_json is not None:
+            add_to_json_records(final_records, haplotype_dict, best_haplotype_score, folder)
 
     write_final_table(final_table, output)
+    if report_json is not None:
+        write_json_report(final_records, report_json)
     LOG.debug("Finished haplogroup prediction")
 
 
@@ -138,6 +151,12 @@ def get_arguments() -> argparse.Namespace:
     parser.add_argument("-o", "--outfile", required=True, help="Output file name", metavar="FILE")
 
     parser.add_argument("-t", "--threads", help="Number of threads to use (default=1).", type=int, default=1)
+
+    parser.add_argument("--report-json", dest="report_json", required=False, metavar="PATH", default=None,
+                        help="Optional path. If set, also emit a schema-versioned JSON sidecar with the "
+                             "same per-sample fields as the TSV plus structured haplogroup info "
+                             "(bare clade, excluded subclades, marker list). Designed for pipeline "
+                             "consumers that prefer json.load() over column-positional TSV parsing.")
 
     args = parser.parse_args()
     return args
@@ -417,6 +436,107 @@ def write_final_table(
         f.write(header)
         for line in final_table:
             f.write('\t'.join(map(str, line)) + "\n")
+
+
+def _maybe_int(value: Any) -> Optional[int]:
+    """Return value coerced to int, or None for the 'NA' sentinel and unparseables."""
+    if value is None or value == "NA":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_float(value: Any) -> Optional[float]:
+    """Return value coerced to float, or None for the 'NA' sentinel and unparseables."""
+    if value is None or value == "NA":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def add_to_json_records(
+    records: List[Dict[str, Any]],
+    haplotype_dict: Dict[str, HgMarkersLinker],
+    best_haplotype_scores: Tuple[str, str, int, int, int, int, int],
+    folder: Path,
+):
+    """Build a structured per-sample record for the JSON sidecar.
+
+    Pulls the same inputs as add_to_final_table but emits typed fields:
+    haplotype is null when the predictor returned NA, the excluded-subclades
+    list is split out from the TSV's "*(xA,xB,...)" syntax, and the marker
+    list is the full set (the TSV truncates at 2 + "etc." for readability).
+    """
+    total_reads, valid_markers = process_info_file(folder / (folder.name + ".info"))
+    hg, ancestral_children, qc1, qc2, qc3, total, _ = best_haplotype_scores
+
+    record: Dict[str, Any] = {
+        "sample_name": folder.name,
+        "haplogroup": None if hg == "NA" else hg,
+        "haplogroup_full": None,
+        "excluded_subclades": [],
+        "hg_markers": [],
+        "total_reads": _maybe_int(total_reads),
+        "valid_markers": _maybe_int(valid_markers),
+        "qc_score": _maybe_float(total),
+        "qc_1": _maybe_float(qc1),
+        "qc_2": _maybe_float(qc2),
+        "qc_3": _maybe_float(qc3),
+    }
+
+    if hg != "NA" and hg in haplotype_dict:
+        markers = sorted(haplotype_dict[hg].get_derived_markers())
+        record["hg_markers"] = markers
+        if isinstance(ancestral_children, list) and ancestral_children:
+            record["excluded_subclades"] = list(ancestral_children)
+            # Match the TSV's existing format exactly (single leading 'x') so
+            # consumers can cross-reference the two files. The
+            # excluded_subclades list above is the canonical structured form.
+            ancestral_string = "x" + ",".join(ancestral_children)
+            record["haplogroup_full"] = f"{hg}*({ancestral_string})"
+        else:
+            record["haplogroup_full"] = hg
+
+    records.append(record)
+
+
+def write_json_report(
+    records: List[Dict[str, Any]],
+    out_file: Union[Path, str],
+):
+    """Write the schema-versioned JSON sidecar.
+
+    Schema (v1):
+      {
+        "schema_version": 1,
+        "yleaf_version": "...",
+        "samples": [
+          { "sample_name": "...", "haplogroup": "I-Y9434" | null,
+            "haplogroup_full": "I-Y9434*(xI-FGC17588,...)" | null,
+            "excluded_subclades": ["I-FGC17588", ...],
+            "hg_markers": ["Y18928", "FGC17581", ...],
+            "total_reads": <int|null>, "valid_markers": <int|null>,
+            "qc_score": <float|null>, "qc_1": ..., "qc_2": ..., "qc_3": ...
+          },
+          ...
+        ]
+      }
+
+    Additive changes (new optional keys) do not bump schema_version; consumers
+    should ignore unknown keys. Renames or semantic changes bump it.
+    """
+    payload = {
+        "schema_version": JSON_REPORT_SCHEMA_VERSION,
+        "yleaf_version": _YLEAF_VERSION,
+        "samples": sorted(records, key=lambda r: r["sample_name"]),
+    }
+    with open(out_file, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
 
 
 def product(


### PR DESCRIPTION
Closes #49.

## Summary

Adds a new optional `--report-json PATH` flag to both
`predict_haplogroup` and `Yleaf`. When set, alongside the existing
TSV the predictor writes a structured JSON document with the same
per-sample data, plus typed fields and the bits the TSV bakes into
strings:

```json
{
  "schema_version": 1,
  "yleaf_version": "3.2.1",
  "samples": [
    {
      "sample_name": "GFX0442453",
      "haplogroup": "I-Y9434",
      "haplogroup_full": "I-Y9434*(xI-FGC17588,I-Y66964,I-Y128435,I-Y85648)",
      "excluded_subclades": ["I-FGC17588", "I-Y66964", "I-Y128435", "I-Y85648"],
      "hg_markers": ["FGC17581", "Y18928"],
      "total_reads": 1082754993,
      "valid_markers": 92074,
      "qc_score": 1.0,
      "qc_1": 1.0, "qc_2": 1.0, "qc_3": 1.0
    }
  ]
}
```

## Design notes

* `haplogroup_full` matches the TSV's `Hg` column **byte-for-byte**
  (single leading `x`) so consumers can cross-reference the two
  files unambiguously. The illustrative example in the issue showed
  repeated `x` per subclade; this implementation prefers staying in
  sync with the existing TSV format.
* `excluded_subclades` is the canonical structured form for the
  exclusion list — consumers should use it instead of parsing
  `haplogroup_full`.
* `hg_markers` is the **full** marker list. The TSV truncates at
  2 + `"etc."` for readability; the JSON does not.
* Numeric fields are real `int` / `float`; the TSV `NA` sentinel
  becomes JSON `null` so `isinstance()` / `is None` checks work.
* `schema_version` is the only API consumers need to gate on.
  Additive changes (new optional keys) won't bump it; renames or
  semantic changes will.

The flag is wholly additive — omitting it is identical to current
behaviour.

## Test plan

- [x] Real `GFX0442453.out` (~92,074 markers) — happy path:
      TSV `Hg` column == JSON `haplogroup_full` byte-for-byte
- [x] Synthetic empty-sample fixture — NA path:
      `haplogroup` and `haplogroup_full` are JSON `null`,
      `excluded_subclades` and `hg_markers` are `[]`,
      numeric fields are `null`
- [x] `predict_haplogroup --help` and `Yleaf --help` both show
      `--report-json PATH`
- [x] Yleaf scan path threads `--report-json` through the internal
      `predict_haplogroup()` wrapper into the predictor's namespace
- [x] JSON is valid (`json.load()` round-trips), pretty-printed with
      `indent=2`, and ends with a trailing newline